### PR TITLE
fix: fix the problem that BackHandler.removeListener is not a function in rn 0.78

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -17,6 +17,7 @@ import {
   View,
   ViewStyle,
   ViewProps,
+  NativeEventSubscription,
 } from 'react-native';
 import * as PropTypes from 'prop-types';
 import * as animatable from 'react-native-animatable';
@@ -206,6 +207,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
   didUpdateDimensionsEmitter: OrNull<EmitterSubscription> = null;
 
   interactionHandle: OrNull<number> = null;
+  backHandlerEventSubscription: OrNull<NativeEventSubscription> = null;
 
   constructor(props: ModalProps) {
     super(props);
@@ -252,14 +254,14 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
     if (this.state.isVisible) {
       this.open();
     }
-    BackHandler.addEventListener('hardwareBackPress', this.onBackButtonPress);
+    this.backHandlerEventSubscription = BackHandler.addEventListener('hardwareBackPress', this.onBackButtonPress);
   }
 
   componentWillUnmount() {
-    BackHandler.removeEventListener(
-      'hardwareBackPress',
-      this.onBackButtonPress,
-    );
+    if (this.backHandlerEventSubscription) {
+      this.backHandlerEventSubscription.remove();
+    }
+
     if (this.didUpdateDimensionsEmitter) {
       this.didUpdateDimensionsEmitter.remove();
     }


### PR DESCRIPTION


# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

 
 **PR Summary by Typo**
------------

**Overview**
This PR addresses a bug where `BackHandler.removeEventListener` throws an error in React Native 0.78. The issue stems from `BackHandler.addEventListener` returning `void` instead of an `EmitterSubscription` object, causing `removeEventListener` to fail.

**Key Changes**
- Added a new variable `backHandlerEventSubscription` to store the return value of `BackHandler.addEventListener`.
- Modified `componentWillUnmount` to check if `backHandlerEventSubscription` exists before calling `remove()`.
- Updated `componentDidMount` to assign the return value of `BackHandler.addEventListener` to `backHandlerEventSubscription`.

**Recommendations**
Deployment ready. This fix addresses a specific bug related to React Native 0.78 compatibility without introducing any new features or significant changes. The targeted nature of the fix minimizes the risk of unintended consequences.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>