### PR TITLE
🚨 fix: type error in react 19.2.0 2

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -732,7 +732,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
 
     const backdropWrapper = (
       <animatable.View
-        ref={ref => (this.backdropRef = ref)}
+        ref={ref => void (this.backdropRef = ref)}
         useNativeDriver={
           useNativeDriverForBackdrop !== undefined
             ? useNativeDriverForBackdrop
@@ -814,7 +814,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
     const containerView = (
       <animatable.View
         {...panHandlers}
-        ref={ref => (this.contentRef = ref)}
+        ref={ref => void (this.contentRef = ref)}
         style={[panPosition, computedStyle]}
         pointerEvents="box-none"
         useNativeDriver={useNativeDriver}


### PR DESCRIPTION

- **fix: type errors in @types/react 19.2.0**

 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a type error that occurs in React 19.2.0 by modifying how refs are assigned within the `ReactNativeModal` component.

#### Key Changes
- Modified `src/modal.tsx` to include the `void` operator in ref assignments for `this.backdropRef` and `this.contentRef`.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| Refactor | 2 (100.0%)    |
| Total Changes | 2         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>